### PR TITLE
resolve toshi connector never calls callback if service fails

### DIFF
--- a/lib/drivers/web_explorer.js
+++ b/lib/drivers/web_explorer.js
@@ -190,7 +190,7 @@ WebExplorer.prototype._request = function (parts, requestor, cb) {
       if (operation.retry(err)) return
 
       if (res.statusCode !== 200) {
-        return operation.retry(new ConnectionRefusedError())
+        operation.retry(new ConnectionRefusedError())
       }
 
       cb(err ? operation.mainError() : null, res.text)


### PR DESCRIPTION
When attempting to call toshis unspent_outputs service, if the address didn't exist (or incoming coins had 0 confirmations) this call would never call the callback and there is infinite retries. 
